### PR TITLE
Release v0.1.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
-KNOWLEDGE_PATH=./examples/knowledge
+# Path to your mounted knowledge directory.
+# Nabu will create this directory on first boot if it does not exist.
+KNOWLEDGE_PATH=/data/nabu/knowledge
+
+# Required: set a real password before deploying.
 NABU_PASSWORD=change-me

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Nabu will be documented in this file.
 
+## [0.1.1] - 2026-04-10
+
+Deployment DX release.
+
+### Shipped
+
+- Automatic creation of `KNOWLEDGE_PATH` on first boot when the directory does not yet exist
+- Simpler default env example for mounted app data at `/data/nabu/knowledge`
+- Updated deployment docs to reflect the mounted parent directory + auto-created knowledge folder flow
+
+### Why it matters
+
+Nabu is aiming for dead-simple self-hosting. A fresh deploy should not fail just because a user forgot to pre-create a subdirectory inside their mounted data path.
+
 ## [0.1.0] - 2026-04-10
 
 First deployable MVP release.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Current direction:
 ## Shipped in v0.1.0
 
 - Mounted vault configuration and validation
+- Automatic vault directory creation on first boot
 - Safe markdown file scanning
 - Frontmatter + metadata normalization
 - In-memory vault indexing primitives
@@ -86,9 +87,11 @@ Set `NABU_PASSWORD` before running for private access (example: `NABU_PASSWORD=c
 Real content should be mounted from a separate path, for example:
 
 ```bash
-KNOWLEDGE_PATH=/data/nabu
+KNOWLEDGE_PATH=/data/nabu/knowledge
 NABU_PASSWORD=change-me
 ```
+
+Mount `/data/nabu` (or another parent app-data directory) as persistent storage and let Nabu create `/knowledge` on first boot if it does not already exist.
 
 Repo-safe demo content can live in `examples/`.
 

--- a/src/lib/vault/config.test.ts
+++ b/src/lib/vault/config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { getVaultConfig } from './config'
@@ -39,6 +39,17 @@ describe('getVaultConfig', () => {
     const config = await getVaultConfig()
 
     expect(config.rootPath).toBe(tempDir)
+  })
+
+  it('creates KNOWLEDGE_PATH when it does not exist yet', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'nabu-vault-config-'))
+    const vaultDir = path.join(tempDir, 'data', 'knowledge')
+    process.env.KNOWLEDGE_PATH = vaultDir
+
+    const config = await getVaultConfig()
+
+    expect(config.rootPath).toBe(vaultDir)
+    await expect(access(vaultDir)).resolves.toBeUndefined()
   })
 
   it('throws when KNOWLEDGE_PATH points to a file', async () => {

--- a/src/lib/vault/config.ts
+++ b/src/lib/vault/config.ts
@@ -1,4 +1,4 @@
-import { stat } from 'node:fs/promises'
+import { mkdir, stat } from 'node:fs/promises'
 import path from 'node:path'
 import { VaultConfigError } from './errors'
 
@@ -14,12 +14,19 @@ export async function getVaultConfig(): Promise<VaultConfig> {
   }
 
   const rootPath = path.resolve(process.cwd(), configuredPath)
-  const rootStat = await stat(rootPath).catch(() => {
-    throw new VaultConfigError(`KNOWLEDGE_PATH does not exist: ${rootPath}`)
-  })
 
-  if (!rootStat.isDirectory()) {
-    throw new VaultConfigError('KNOWLEDGE_PATH must point to a directory.')
+  try {
+    const rootStat = await stat(rootPath)
+
+    if (!rootStat.isDirectory()) {
+      throw new VaultConfigError('KNOWLEDGE_PATH must point to a directory.')
+    }
+  } catch (error) {
+    if (error instanceof VaultConfigError) {
+      throw error
+    }
+
+    await mkdir(rootPath, { recursive: true })
   }
 
   return {


### PR DESCRIPTION
## Summary

Promote deployment DX improvements from `main` to `release`.

## Shipped in v0.1.1

- auto-create `KNOWLEDGE_PATH` on first boot if missing
- default `.env.example` now points at `/data/nabu/knowledge`
- docs updated for mounted parent data dir flow

## Validation

- `bun run test:bun src/lib/vault/config.test.ts`
- `bun run lint`
- `bun run build`