### PR TITLE
release: ship v0.3.0 to hosted branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Nabu will be documented in this file.
 
+## [0.3.0] - 2026-04-13
+
+Workspace polish release.
+
+### Shipped
+
+- Obsidian-inspired workspace overhaul with a darker, denser, calmer reading interface
+- Stronger pane hierarchy across navigation, note list/search, and note content
+- Improved markdown presentation for headings, code blocks, blockquotes, and note metadata
+- CI reliability fix by syncing `package-lock.json` with the release version bump
+
+### Why it matters
+
+Nabu now feels much closer to a real knowledge workspace instead of a generic web dashboard. The reading surface has more authority, the side rails are calmer, and the hosted branch release process is back in a clean state after the CI lockfile fix.
+
 ## [0.2.0] - 2026-04-13
 
 Agent-operability release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nabu",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nabu",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nabu",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "An open-source markdown-native knowledge OS for humans and agents.",
   "scripts": {


### PR DESCRIPTION
## Summary
- ship the v0.3.0 release prep from `main` to `release`
- includes the Obsidian-inspired workspace overhaul and release metadata

## Included
- UI overhaul with calmer, denser workspace styling
- improved markdown reading presentation
- synced release metadata for v0.3.0

## Why
The hosted environment tracks the `release` branch, so the release metadata must land there before cutting the GitHub release tag.